### PR TITLE
Refactor Topology Toolbox

### DIFF
--- a/docs/source/notebooks/ogb_biokg_demo.ipynb
+++ b/docs/source/notebooks/ogb_biokg_demo.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "import sys\n",
     "!{sys.executable} -m pip uninstall -y kg_topology_toolbox\n",
-    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git@refactor_kgtt\n",
+    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git@refactor_kgtt --no-cache-dir\n",
     "!pip install -q jupyter ipywidgets ogb seaborn"
    ]
   },
@@ -204,16 +204,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Based on this representation of the knowledge graph, we can proceed to compute its topological properties using the `KGTopologyToolbox` class."
+    "Based on this representation of the knowledge graph, we can proceed to instantiate the `KGTopologyToolbox` class to compute topological properties."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/nethome/albertoc/research/knowledge_graphs/kg-topology-toolbox/.venv/lib/python3.10/site-packages/kg_topology_toolbox/topology_toolbox.py:64: UserWarning: The Knowledge Graph contains duplicated edges -- some functionalities may produce incorrect results\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "kgtt = KGTopologyToolbox(biokg_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice the warning raised by the constructor, which detects duplicated edges in the `biokg_df` DataFrame: to ensure optimal functionalities, duplicated edges should be removed before instantiating the `KGTopologyToolbox` class."
    ]
   },
   {
@@ -399,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -439,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -493,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -520,11 +536,11 @@
        "      <th>h</th>\n",
        "      <th>r</th>\n",
        "      <th>t</th>\n",
-       "      <th>h_unique_rel</th>\n",
        "      <th>h_degree</th>\n",
+       "      <th>h_unique_rel</th>\n",
        "      <th>h_degree_same_rel</th>\n",
-       "      <th>t_unique_rel</th>\n",
        "      <th>t_degree</th>\n",
+       "      <th>t_unique_rel</th>\n",
        "      <th>t_degree_same_rel</th>\n",
        "      <th>tot_degree</th>\n",
        "      <th>tot_degree_same_rel</th>\n",
@@ -538,11 +554,11 @@
        "      <td>1718</td>\n",
        "      <td>0</td>\n",
        "      <td>3207</td>\n",
-       "      <td>5</td>\n",
        "      <td>191</td>\n",
+       "      <td>5</td>\n",
        "      <td>116</td>\n",
-       "      <td>6</td>\n",
        "      <td>46</td>\n",
+       "      <td>6</td>\n",
        "      <td>14</td>\n",
        "      <td>236</td>\n",
        "      <td>129</td>\n",
@@ -554,11 +570,11 @@
        "      <td>4903</td>\n",
        "      <td>0</td>\n",
        "      <td>13662</td>\n",
-       "      <td>8</td>\n",
        "      <td>544</td>\n",
+       "      <td>8</td>\n",
        "      <td>33</td>\n",
-       "      <td>9</td>\n",
        "      <td>1975</td>\n",
+       "      <td>9</td>\n",
        "      <td>50</td>\n",
        "      <td>2518</td>\n",
        "      <td>82</td>\n",
@@ -570,11 +586,11 @@
        "      <td>5480</td>\n",
        "      <td>0</td>\n",
        "      <td>15999</td>\n",
-       "      <td>3</td>\n",
        "      <td>108</td>\n",
+       "      <td>3</td>\n",
        "      <td>5</td>\n",
-       "      <td>4</td>\n",
        "      <td>72</td>\n",
+       "      <td>4</td>\n",
        "      <td>22</td>\n",
        "      <td>179</td>\n",
        "      <td>26</td>\n",
@@ -586,11 +602,11 @@
        "      <td>3148</td>\n",
        "      <td>0</td>\n",
        "      <td>7247</td>\n",
-       "      <td>4</td>\n",
        "      <td>110</td>\n",
+       "      <td>4</td>\n",
        "      <td>99</td>\n",
-       "      <td>11</td>\n",
        "      <td>673</td>\n",
+       "      <td>11</td>\n",
        "      <td>271</td>\n",
        "      <td>782</td>\n",
        "      <td>369</td>\n",
@@ -602,11 +618,11 @@
        "      <td>10300</td>\n",
        "      <td>0</td>\n",
        "      <td>16202</td>\n",
-       "      <td>4</td>\n",
        "      <td>414</td>\n",
+       "      <td>4</td>\n",
        "      <td>315</td>\n",
-       "      <td>6</td>\n",
        "      <td>148</td>\n",
+       "      <td>6</td>\n",
        "      <td>31</td>\n",
        "      <td>561</td>\n",
        "      <td>345</td>\n",
@@ -634,11 +650,11 @@
        "      <td>2451</td>\n",
        "      <td>50</td>\n",
        "      <td>5097</td>\n",
-       "      <td>5</td>\n",
        "      <td>636</td>\n",
+       "      <td>5</td>\n",
        "      <td>272</td>\n",
-       "      <td>10</td>\n",
        "      <td>803</td>\n",
+       "      <td>10</td>\n",
        "      <td>272</td>\n",
        "      <td>1437</td>\n",
        "      <td>543</td>\n",
@@ -650,11 +666,11 @@
        "      <td>6456</td>\n",
        "      <td>50</td>\n",
        "      <td>8833</td>\n",
-       "      <td>10</td>\n",
        "      <td>743</td>\n",
-       "      <td>259</td>\n",
        "      <td>10</td>\n",
+       "      <td>259</td>\n",
        "      <td>371</td>\n",
+       "      <td>10</td>\n",
        "      <td>100</td>\n",
        "      <td>1111</td>\n",
        "      <td>358</td>\n",
@@ -666,11 +682,11 @@
        "      <td>9484</td>\n",
        "      <td>50</td>\n",
        "      <td>15873</td>\n",
-       "      <td>8</td>\n",
        "      <td>652</td>\n",
+       "      <td>8</td>\n",
        "      <td>213</td>\n",
-       "      <td>6</td>\n",
        "      <td>486</td>\n",
+       "      <td>6</td>\n",
        "      <td>163</td>\n",
        "      <td>1135</td>\n",
        "      <td>375</td>\n",
@@ -682,11 +698,11 @@
        "      <td>6365</td>\n",
        "      <td>50</td>\n",
        "      <td>496</td>\n",
-       "      <td>9</td>\n",
        "      <td>922</td>\n",
+       "      <td>9</td>\n",
        "      <td>277</td>\n",
-       "      <td>19</td>\n",
        "      <td>618</td>\n",
+       "      <td>19</td>\n",
        "      <td>173</td>\n",
        "      <td>1537</td>\n",
        "      <td>449</td>\n",
@@ -698,11 +714,11 @@
        "      <td>13860</td>\n",
        "      <td>50</td>\n",
        "      <td>6368</td>\n",
-       "      <td>7</td>\n",
        "      <td>485</td>\n",
+       "      <td>7</td>\n",
        "      <td>175</td>\n",
-       "      <td>8</td>\n",
        "      <td>455</td>\n",
+       "      <td>8</td>\n",
        "      <td>147</td>\n",
        "      <td>939</td>\n",
        "      <td>321</td>\n",
@@ -715,31 +731,31 @@
        "</div>"
       ],
       "text/plain": [
-       "             h   r      t  h_unique_rel  h_degree  h_degree_same_rel  \\\n",
-       "0         1718   0   3207             5       191                116   \n",
-       "1         4903   0  13662             8       544                 33   \n",
-       "2         5480   0  15999             3       108                  5   \n",
-       "3         3148   0   7247             4       110                 99   \n",
-       "4        10300   0  16202             4       414                315   \n",
-       "...        ...  ..    ...           ...       ...                ...   \n",
-       "5088429   2451  50   5097             5       636                272   \n",
-       "5088430   6456  50   8833            10       743                259   \n",
-       "5088431   9484  50  15873             8       652                213   \n",
-       "5088432   6365  50    496             9       922                277   \n",
-       "5088433  13860  50   6368             7       485                175   \n",
+       "             h   r      t  h_degree  h_unique_rel  h_degree_same_rel  \\\n",
+       "0         1718   0   3207       191             5                116   \n",
+       "1         4903   0  13662       544             8                 33   \n",
+       "2         5480   0  15999       108             3                  5   \n",
+       "3         3148   0   7247       110             4                 99   \n",
+       "4        10300   0  16202       414             4                315   \n",
+       "...        ...  ..    ...       ...           ...                ...   \n",
+       "5088429   2451  50   5097       636             5                272   \n",
+       "5088430   6456  50   8833       743            10                259   \n",
+       "5088431   9484  50  15873       652             8                213   \n",
+       "5088432   6365  50    496       922             9                277   \n",
+       "5088433  13860  50   6368       485             7                175   \n",
        "\n",
-       "         t_unique_rel  t_degree  t_degree_same_rel  tot_degree  \\\n",
-       "0                   6        46                 14         236   \n",
-       "1                   9      1975                 50        2518   \n",
-       "2                   4        72                 22         179   \n",
-       "3                  11       673                271         782   \n",
-       "4                   6       148                 31         561   \n",
-       "...               ...       ...                ...         ...   \n",
-       "5088429            10       803                272        1437   \n",
-       "5088430            10       371                100        1111   \n",
-       "5088431             6       486                163        1135   \n",
-       "5088432            19       618                173        1537   \n",
-       "5088433             8       455                147         939   \n",
+       "         t_degree  t_unique_rel  t_degree_same_rel  tot_degree  \\\n",
+       "0              46             6                 14         236   \n",
+       "1            1975             9                 50        2518   \n",
+       "2              72             4                 22         179   \n",
+       "3             673            11                271         782   \n",
+       "4             148             6                 31         561   \n",
+       "...           ...           ...                ...         ...   \n",
+       "5088429       803            10                272        1437   \n",
+       "5088430       371            10                100        1111   \n",
+       "5088431       486             6                163        1135   \n",
+       "5088432       618            19                173        1537   \n",
+       "5088433       455             8                147         939   \n",
        "\n",
        "         tot_degree_same_rel triple_cardinality triple_cardinality_same_rel  \n",
        "0                        129                M:M                         M:M  \n",
@@ -757,7 +773,7 @@
        "[5088434 rows x 13 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -776,7 +792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -839,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -874,7 +890,7 @@
    "source": [
     "### Edge topological patterns\n",
     "\n",
-    "The second method provided by `KGTopologyToolbox` for topological analysis at the edge level is `edge_pattern_summary`, which extracts information on several significant edge topological patterns. In particular, it detects whether the edge (h,r,t) is a loop, is symmetric or has inverse, inference, composition (directed and undirected):\n",
+    "`KGTopologyToolbox` also allows us to perform a topological analysis at the edge level, using the method `edge_pattern_summary`, which extracts information on several significant edge topological patterns. In particular, it detects whether the edge (h,r,t) is a loop, is symmetric or has inverse, inference, composition (directed and undirected):\n",
     "\n",
     "![image info](../images/edge_patterns.png)\n",
     "\n",
@@ -883,7 +899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1184,7 +1200,7 @@
        "[5088434 rows x 15 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1196,7 +1212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1217,7 +1233,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1231,7 +1247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1267,12 +1283,12 @@
    "source": [
     "## Relation-level analysis\n",
     "\n",
-    "The method `aggregate_by_relation` allows the user to aggregate at the relation-level the statistics outputted by the edge-level methods `edge_degree_cardinality_summary` and `edge_pattern_summary`. This converts DataFrames indexed on the KG edges to DataFrames indexed on the IDs of the unique relation types."
+    "All edge topological properties seen in the previous section can be aggregated over triples of the same relation type, to produce relation-level statistics. To do so, we can either set the option `aggregate_by_r = True` when calling the methods `edge_degree_cardinality_summary`, `edge_pattern_summary`, or - if edge topological metrics have already been precomputed - use the utility function `aggregate_by_relation`, which converts DataFrames indexed on the KG edges to DataFrames indexed on the IDs of the unique relation types."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1300,12 +1316,12 @@
        "      <th>frac_triples</th>\n",
        "      <th>unique_h</th>\n",
        "      <th>unique_t</th>\n",
-       "      <th>h_unique_rel_mean</th>\n",
-       "      <th>h_unique_rel_std</th>\n",
-       "      <th>h_unique_rel_quartile1</th>\n",
-       "      <th>h_unique_rel_quartile2</th>\n",
-       "      <th>h_unique_rel_quartile3</th>\n",
        "      <th>h_degree_mean</th>\n",
+       "      <th>h_degree_std</th>\n",
+       "      <th>h_degree_quartile1</th>\n",
+       "      <th>h_degree_quartile2</th>\n",
+       "      <th>h_degree_quartile3</th>\n",
+       "      <th>h_unique_rel_mean</th>\n",
        "      <th>...</th>\n",
        "      <th>tot_degree_same_rel_quartile1</th>\n",
        "      <th>tot_degree_same_rel_quartile2</th>\n",
@@ -1350,12 +1366,12 @@
        "      <td>0.015931</td>\n",
        "      <td>9742</td>\n",
        "      <td>9337</td>\n",
-       "      <td>8.110293</td>\n",
-       "      <td>8.247277</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>8.0</td>\n",
        "      <td>569.252202</td>\n",
+       "      <td>1083.315332</td>\n",
+       "      <td>111.0</td>\n",
+       "      <td>222.0</td>\n",
+       "      <td>521.0</td>\n",
+       "      <td>8.110293</td>\n",
        "      <td>...</td>\n",
        "      <td>45.0</td>\n",
        "      <td>112.0</td>\n",
@@ -1374,12 +1390,12 @@
        "      <td>0.001114</td>\n",
        "      <td>698</td>\n",
        "      <td>1536</td>\n",
-       "      <td>27.048157</td>\n",
-       "      <td>12.936410</td>\n",
-       "      <td>17.0</td>\n",
-       "      <td>31.0</td>\n",
-       "      <td>36.0</td>\n",
        "      <td>2518.765391</td>\n",
+       "      <td>2186.452620</td>\n",
+       "      <td>435.0</td>\n",
+       "      <td>2087.0</td>\n",
+       "      <td>4028.0</td>\n",
+       "      <td>27.048157</td>\n",
        "      <td>...</td>\n",
        "      <td>14.0</td>\n",
        "      <td>32.0</td>\n",
@@ -1398,12 +1414,12 @@
        "      <td>0.013158</td>\n",
        "      <td>612</td>\n",
        "      <td>612</td>\n",
-       "      <td>36.404307</td>\n",
-       "      <td>5.600706</td>\n",
-       "      <td>33.0</td>\n",
-       "      <td>36.0</td>\n",
-       "      <td>41.0</td>\n",
        "      <td>4129.511919</td>\n",
+       "      <td>1935.630599</td>\n",
+       "      <td>2548.0</td>\n",
+       "      <td>3968.0</td>\n",
+       "      <td>5649.0</td>\n",
+       "      <td>36.404307</td>\n",
        "      <td>...</td>\n",
        "      <td>332.0</td>\n",
        "      <td>404.0</td>\n",
@@ -1422,12 +1438,12 @@
        "      <td>0.003849</td>\n",
        "      <td>491</td>\n",
        "      <td>491</td>\n",
-       "      <td>37.095941</td>\n",
-       "      <td>5.547389</td>\n",
-       "      <td>33.0</td>\n",
-       "      <td>37.0</td>\n",
-       "      <td>41.0</td>\n",
        "      <td>4527.399592</td>\n",
+       "      <td>1943.714179</td>\n",
+       "      <td>2925.0</td>\n",
+       "      <td>4507.0</td>\n",
+       "      <td>6161.0</td>\n",
+       "      <td>37.095941</td>\n",
        "      <td>...</td>\n",
        "      <td>114.0</td>\n",
        "      <td>157.0</td>\n",
@@ -1446,12 +1462,12 @@
        "      <td>0.006295</td>\n",
        "      <td>526</td>\n",
        "      <td>525</td>\n",
-       "      <td>37.319567</td>\n",
-       "      <td>5.384523</td>\n",
-       "      <td>34.0</td>\n",
-       "      <td>38.0</td>\n",
-       "      <td>41.0</td>\n",
        "      <td>4511.067834</td>\n",
+       "      <td>1905.395180</td>\n",
+       "      <td>2931.0</td>\n",
+       "      <td>4507.0</td>\n",
+       "      <td>6148.0</td>\n",
+       "      <td>37.319567</td>\n",
        "      <td>...</td>\n",
        "      <td>188.0</td>\n",
        "      <td>243.0</td>\n",
@@ -1470,29 +1486,29 @@
        "</div>"
       ],
       "text/plain": [
-       "   num_triples  frac_triples  unique_h  unique_t  h_unique_rel_mean  \\\n",
-       "r                                                                     \n",
-       "0        81066      0.015931      9742      9337           8.110293   \n",
-       "1         5669      0.001114       698      1536          27.048157   \n",
-       "2        66954      0.013158       612       612          36.404307   \n",
-       "3        19585      0.003849       491       491          37.095941   \n",
-       "4        32034      0.006295       526       525          37.319567   \n",
+       "   num_triples  frac_triples  unique_h  unique_t  h_degree_mean  h_degree_std  \\\n",
+       "r                                                                               \n",
+       "0        81066      0.015931      9742      9337     569.252202   1083.315332   \n",
+       "1         5669      0.001114       698      1536    2518.765391   2186.452620   \n",
+       "2        66954      0.013158       612       612    4129.511919   1935.630599   \n",
+       "3        19585      0.003849       491       491    4527.399592   1943.714179   \n",
+       "4        32034      0.006295       526       525    4511.067834   1905.395180   \n",
        "\n",
-       "   h_unique_rel_std  h_unique_rel_quartile1  h_unique_rel_quartile2  \\\n",
-       "r                                                                     \n",
-       "0          8.247277                     4.0                     5.0   \n",
-       "1         12.936410                    17.0                    31.0   \n",
-       "2          5.600706                    33.0                    36.0   \n",
-       "3          5.547389                    33.0                    37.0   \n",
-       "4          5.384523                    34.0                    38.0   \n",
+       "   h_degree_quartile1  h_degree_quartile2  h_degree_quartile3  \\\n",
+       "r                                                               \n",
+       "0               111.0               222.0               521.0   \n",
+       "1               435.0              2087.0              4028.0   \n",
+       "2              2548.0              3968.0              5649.0   \n",
+       "3              2925.0              4507.0              6161.0   \n",
+       "4              2931.0              4507.0              6148.0   \n",
        "\n",
-       "   h_unique_rel_quartile3  h_degree_mean  ...  tot_degree_same_rel_quartile1  \\\n",
-       "r                                         ...                                  \n",
-       "0                     8.0     569.252202  ...                           45.0   \n",
-       "1                    36.0    2518.765391  ...                           14.0   \n",
-       "2                    41.0    4129.511919  ...                          332.0   \n",
-       "3                    41.0    4527.399592  ...                          114.0   \n",
-       "4                    41.0    4511.067834  ...                          188.0   \n",
+       "   h_unique_rel_mean  ...  tot_degree_same_rel_quartile1  \\\n",
+       "r                     ...                                  \n",
+       "0           8.110293  ...                           45.0   \n",
+       "1          27.048157  ...                           14.0   \n",
+       "2          36.404307  ...                          332.0   \n",
+       "3          37.095941  ...                          114.0   \n",
+       "4          37.319567  ...                          188.0   \n",
        "\n",
        "   tot_degree_same_rel_quartile2  tot_degree_same_rel_quartile3  \\\n",
        "r                                                                 \n",
@@ -1537,27 +1553,29 @@
        "[5 rows x 51 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "kgtt.aggregate_by_relation(edge_dcs).head()"
+    "from kg_topology_toolbox.utils import aggregate_by_relation\n",
+    "\n",
+    "aggregate_by_relation(edge_dcs).head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice on the left the columns `num_triples`, `frac_triples`, `unique_h`, `unique_t` giving additional statistics for relation types (number of edges and relative frequency, number of unique entities used as heads/tails by triples of the relation type).\n",
+    "Notice on the extra columns `num_triples`, `frac_triples`, `unique_h`, `unique_t` giving additional statistics for relation types (number of edges and relative frequency, number of unique entities used as heads/tails by triples of the relation type).\n",
     "\n",
     "Similarly, by aggregating the `edge_eps` DataFrame we can look at the distribution of edge topological patterns within each relation type."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1814,25 +1832,25 @@
        "[5 rows x 32 columns]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "kgtt.aggregate_by_relation(edge_eps).head()"
+    "aggregate_by_relation(edge_eps).head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Additional methods are provided for the analysis at the relation level: `jaccard_similarity_relation_sets` to compute the Jaccard similarity of the sets of head/tail entities used by each relation; `relational_affinity_ingram` to compute the InGram pairwise relation similarity (see [paper](https://arxiv.org/abs/2305.19987)). "
+    "Additional methods are provided in the `KGTopologyToolbox` class for analysis at the relation level: `jaccard_similarity_relation_sets` to compute the Jaccard similarity of the sets of head/tail entities used by each relation; `relational_affinity_ingram` to compute the InGram pairwise relation similarity (see [paper](https://arxiv.org/abs/2305.19987)). "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -2108,7 +2126,7 @@
        "[1275 rows x 14 columns]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2119,7 +2137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -2237,7 +2255,7 @@
        "[2550 rows x 3 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/source/notebooks/ogb_biokg_demo.ipynb
+++ b/docs/source/notebooks/ogb_biokg_demo.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -31,13 +31,13 @@
    "source": [
     "import sys\n",
     "!{sys.executable} -m pip uninstall -y kg_topology_toolbox\n",
-    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git\n",
+    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git@refactor_kgtt\n",
     "!pip install -q jupyter ipywidgets ogb seaborn"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +181,7 @@
        "[5088434 rows x 3 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -194,7 +194,9 @@
     "all_triples = []\n",
     "for split in dataset.get_edge_split().values():\n",
     "    all_triples.append(np.stack([split[\"head\"], split[\"relation\"], split[\"tail\"]]).T)\n",
-    "biokg_df = pd.DataFrame(np.concatenate(all_triples), columns=[\"h\", \"r\", \"t\"])\n",
+    "biokg_df = pd.DataFrame(\n",
+    "    np.concatenate(all_triples).astype(np.int32), columns=[\"h\", \"r\", \"t\"]\n",
+    ")\n",
     "biokg_df"
    ]
   },
@@ -207,11 +209,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "kgtt = KGTopologyToolbox()"
+    "kgtt = KGTopologyToolbox(biokg_df)"
    ]
   },
   {
@@ -231,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -385,13 +387,13 @@
        "[45085 rows x 6 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "node_ds = kgtt.node_degree_summary(biokg_df)\n",
+    "node_ds = kgtt.node_degree_summary()\n",
     "node_ds"
    ]
   },
@@ -491,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -755,13 +757,13 @@
        "[5088434 rows x 13 columns]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "edge_dcs = kgtt.edge_degree_cardinality_summary(biokg_df)\n",
+    "edge_dcs = kgtt.edge_degree_cardinality_summary()\n",
     "edge_dcs"
    ]
   },
@@ -881,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1182,19 +1184,19 @@
        "[5088434 rows x 15 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "edge_eps = kgtt.edge_pattern_summary(biokg_df)\n",
+    "edge_eps = kgtt.edge_pattern_summary()\n",
     "edge_eps"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1215,7 +1217,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1270,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1535,7 +1537,7 @@
        "[5 rows x 51 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1555,7 +1557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1812,7 +1814,7 @@
        "[5 rows x 32 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1830,7 +1832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -2106,18 +2108,18 @@
        "[1275 rows x 14 columns]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "kgtt.jaccard_similarity_relation_sets(biokg_df)"
+    "kgtt.jaccard_similarity_relation_sets()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -2235,13 +2237,13 @@
        "[2550 rows x 3 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "kgtt.relational_affinity_ingram(biokg_df)"
+    "kgtt.relational_affinity_ingram()"
    ]
   }
  ],

--- a/docs/source/notebooks/ogb_biokg_demo.ipynb
+++ b/docs/source/notebooks/ogb_biokg_demo.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "import sys\n",
     "!{sys.executable} -m pip uninstall -y kg_topology_toolbox\n",
-    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git@refactor_kgtt --no-cache-dir\n",
+    "!pip install -q git+https://github.com/graphcore-research/kg-topology-toolbox.git --no-cache-dir\n",
     "!pip install -q jupyter ipywidgets ogb seaborn"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kg-topology-toolbox"
-version = "0.1.0"
+version = "1.0.0"
 authors = [
     {name = "Alberto Cattaneo"},
     {name = "Daniel Justus"},

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -312,7 +312,10 @@ class KGTopologyToolbox:
               the subgraph of edges with relation type r.
         """
         df_res = pd.merge(
-            self.edge_head_degree(), self.edge_tail_degree(), on=["h", "r", "t"]
+            self.edge_head_degree(),
+            self.edge_tail_degree(),
+            on=["h", "r", "t"],
+            how="left",
         )
         # compute number of parallel edges to avoid double-counting them
         # in total degree

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -311,11 +311,12 @@ class KGTopologyToolbox:
             - **triple_cardinality_same_rel** (int): cardinality type of the edge in
               the subgraph of edges with relation type r.
         """
-        df_res = pd.merge(
-            self.edge_head_degree(),
-            self.edge_tail_degree(),
-            on=["h", "r", "t"],
-            how="left",
+        df_res = pd.concat(
+            [
+                self.edge_head_degree(),
+                self.edge_tail_degree().drop(columns=["h", "r", "t"]),
+            ],
+            axis=1,
         )
         # compute number of parallel edges to avoid double-counting them
         # in total degree

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -5,16 +5,15 @@
 Topology toolbox main functionalities
 """
 
-import warnings
 from functools import cache
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_integer_dtype
 from scipy.sparse import coo_array
 
 from kg_topology_toolbox.utils import (
     aggregate_by_relation,
+    check_kg_df_structure,
     composition_count,
     jaccard_similarity,
     node_degrees_and_rels,
@@ -49,22 +48,11 @@ class KGTopologyToolbox:
             The name of the column with the IDs of tail entities. Default: "t".
 
         """
-        for col_name in [head_column, relation_column, tail_column]:
-            if col_name in kg_df.columns:
-                if not is_integer_dtype(kg_df[col_name]):
-                    raise TypeError(
-                        f"Column {col_name} needs to be of an integer dtype"
-                    )
-            else:
-                raise ValueError(f"DataFrame {kg_df} has no column named {col_name}")
+        check_kg_df_structure(kg_df, head_column, relation_column, tail_column)
+
         self.df = kg_df[[head_column, relation_column, tail_column]].rename(
             columns={head_column: "h", relation_column: "r", tail_column: "t"}
         )
-        if self.df.duplicated().any():
-            warnings.warn(
-                "The Knowledge Graph contains duplicated edges"
-                " -- some functionalities may produce incorrect results"
-            )
         self.n_entity = self.df[["h", "t"]].max().max() + 1
         self.n_rel = self.df.r.max() + 1
 

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -7,7 +7,7 @@ Topology toolbox main functionalities
 
 from collections.abc import Iterable
 from functools import cache
-
+import warnings
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_integer_dtype
@@ -59,6 +59,11 @@ class KGTopologyToolbox:
         self.df = kg_df[[head_column, relation_column, tail_column]].rename(
             columns={head_column: "h", relation_column: "r", tail_column: "t"}
         )
+        if self.df.duplicated(subset=["h", "r", "t"]).any():
+            warnings.warn(
+                "The Knowledge Graph contains duplicated edges"
+                " -- some functionalities may produce incorrect results"
+            )
         self.n_entity = self.df[["h", "t"]].max().max() + 1
         self.n_rel = self.df.r.max() + 1
 

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -60,7 +60,7 @@ class KGTopologyToolbox:
         self.df = kg_df[[head_column, relation_column, tail_column]].rename(
             columns={head_column: "h", relation_column: "r", tail_column: "t"}
         )
-        if self.df.duplicated(subset=["h", "r", "t"]).any():
+        if self.df.duplicated().any():
             warnings.warn(
                 "The Knowledge Graph contains duplicated edges"
                 " -- some functionalities may produce incorrect results"

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -31,6 +31,7 @@ def node_degrees_and_rels(
     :return:
         The result DataFrame, indexed on the IDs of the graph entities,
         with columns:
+
         - **degree** (int): Number of triples in the aggregation.
         - **unique_rel** (int): Number of distinct relation types
             in the set of aggregated edges.

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -4,6 +4,7 @@
 Utility functions
 """
 
+from collections.abc import Iterable
 from multiprocessing import Pool
 
 import numpy as np
@@ -50,6 +51,89 @@ def node_degrees_and_rels(
         deg_df[["degree", "unique_rel"]].fillna(0).astype(int)
     )
     return deg_df
+
+
+def aggregate_by_relation(edge_topology_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Aggregate topology metrics of all triples of the same relation type.
+    To be applied to a DataFrame of metrics having at least columns
+    `h`, `r`, `t` (e.g., the output of
+    :meth:`KGTopologyToolbox.edge_degree_cardinality_summary` or
+    :meth:`KGTopologyToolbox.edge_pattern_summary`).
+
+    The returned dataframe is indexed over relation type IDs, with columns
+    giving the aggregated statistics of triples of the corresponding relation.
+    The name of the columns is of the form ``column_name_in_input_df + suffix``.
+    The aggregation is performed by returning:
+
+    - for numerical metrics: mean, standard deviation and quartiles
+      (``suffix`` = "_mean", "_std", "_quartile1", "_quartile2", "_quartile3");
+    - for boolean metrics: the fraction of triples of the relation type
+      with metric = True (``suffix`` = "_frac");
+    - for string metrics: for each possible label, the fraction of triples
+      of the relation type with that metric value (``suffix`` = "_{label}_frac")
+    - for list metrics: the unique metric values across triples of the relation
+      type (``suffix`` = "_unique").
+
+    :param edge_topology_df:
+        pd.DataFrame of edge topology metrics.
+        Must contain at least three columns `h`, `r`, `t`.
+
+    :return:
+        The results dataframe. In addition to the columns with the aggregated
+        metrics by relation type, it also contains columns:
+
+        - **num_triples** (int): Number of triples for each relation type.
+        - **frac_triples** (float): Fraction of overall triples represented by each
+          relation type.
+        - **unique_h** (int): Number of unique head entities used by triples of each
+          relation type.
+        - **unique_t** (int): Number of unique tail entities used by triples of each
+          relation type.
+    """
+    df_by_r = edge_topology_df.groupby("r")
+    df_res = df_by_r.agg(num_triples=("r", "count"))
+    df_res["frac_triples"] = df_res["num_triples"] / edge_topology_df.shape[0]
+    col: str
+    for col, col_dtype in edge_topology_df.drop(columns=["r"]).dtypes.items():  # type: ignore
+        if col in ["h", "t"]:
+            df_res[f"unique_{col}"] = df_by_r[col].nunique()
+        elif col_dtype == object:
+            if isinstance(edge_topology_df[col].iloc[0], str):
+                for label in np.unique(edge_topology_df[col]):
+                    df_res[f"{col}_{label}_frac"] = (
+                        edge_topology_df[edge_topology_df[col] == label]
+                        .groupby("r")[col]
+                        .count()
+                        / df_res["num_triples"]
+                    ).fillna(0)
+            elif isinstance(edge_topology_df[col].iloc[0], Iterable):
+                df_res[f"{col}_unique"] = (
+                    df_by_r[col]
+                    .agg(np.unique)
+                    .apply(
+                        lambda x: (
+                            np.unique(
+                                np.concatenate(
+                                    [lst for lst in x if len(lst) > 0] or [[]]
+                                )
+                            ).tolist()
+                        )
+                    )
+                )
+            else:
+                print(f"Skipping column {col}: no known aggregation mode")
+                continue
+        elif col_dtype == int or col_dtype == float:
+            df_res[f"{col}_mean"] = df_by_r[col].mean()
+            df_res[f"{col}_std"] = df_by_r[col].std()
+            for q in range(1, 4):
+                df_res[f"{col}_quartile{q}"] = df_by_r[col].agg(
+                    lambda x: np.quantile(x, 0.25 * q)
+                )
+        elif col_dtype == bool:
+            df_res[f"{col}_frac"] = df_by_r[col].mean()
+    return df_res
 
 
 def jaccard_similarity(

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -12,16 +12,58 @@ from numpy.typing import NDArray
 from scipy.sparse import coo_array, csc_array, csr_array
 
 
+def node_degrees_and_rels(
+    df: pd.DataFrame, column: str, n_entity: int, return_relation_list: bool
+) -> pd.DataFrame:
+    """
+    Aggregate edges by head/tail node and compute associated statistics.
+
+    :param df:
+        Dataframe of (h,r,t) triples.
+    :param column:
+        Name of the column used to aggregate edges.
+    :param n_entity:
+        Total number of entities in the graph.
+    :param return_relation_list:
+        If True, return the list of unique relations types
+        in the set of aggregated edges.
+
+    :return:
+        The result DataFrame, indexed on the IDs of the graph entities,
+        with columns:
+        - **degree** (int): Number of triples in the aggregation.
+        - **unique_rel** (int): Number of distinct relation types
+            in the set of aggregated edges.
+        - **rel_list** (Optional[list]): List of unique relation types
+            in the set of aggregated edges.
+            Only returned if `return_relation_list = True`.
+    """
+    rel_list = {"rel_list": ("r", "unique")} if return_relation_list else {}
+    deg_df = pd.DataFrame(
+        df.groupby(column).agg(
+            degree=("r", "count"), unique_rel=("r", "nunique"), **rel_list  # type: ignore
+        ),
+        index=np.arange(n_entity),
+    )
+    deg_df[["degree", "unique_rel"]] = (
+        deg_df[["degree", "unique_rel"]].fillna(0).astype(int)
+    )
+    return deg_df
+
+
 def jaccard_similarity(
     entities_1: NDArray[np.int32], entities_2: NDArray[np.int32]
 ) -> float:
     """
     Jaccard Similarity function for two sets of entities.
 
-    :param entities_1: the array of IDs for the first set of entities.
-    :param entities_2: the array of IDs for the second set of entities.
+    :param entities_1:
+        Array of IDs for the first set of entities.
+    :param entities_2:
+        Array of IDs for the second set of entities.
 
-    :return: Jaccard Similarity score for two sets of entities.
+    :return:
+        Jaccard Similarity score for two sets of entities.
     """
     intersection = len(np.intersect1d(entities_1, entities_2))
     union = len(entities_1) + len(entities_2) - intersection
@@ -48,16 +90,20 @@ def composition_count(
 ) -> pd.DataFrame:
     """A helper function to compute the composition count of a graph.
 
-    :param df: A graph represented as a pd.DataFrame. Must contain the columns
+    :param df:
+        A graph represented as a pd.DataFrame. Must contain the columns
         `h` and `t`. No self-loops should be present in the graph.
-    :param chunk_size: Size of chunks of columns of the adjacency matrix to be
+    :param chunk_size:
+        Size of chunks of columns of the adjacency matrix to be
         processed together.
-    :param workers: Number of workers processing chunks concurrently
-    :param directed: Boolean flag. If false, bidirectional edges are considered for
-        triangles by adding the adjacency matrix and its transposed. Defaults to True.
+    :param workers:
+        Number of workers processing chunks concurrently
+    :param directed:
+        Boolean flag. If false, bidirectional edges are considered for
+        triangles by adding the adjacency matrix and its transposed. Default: True.
 
-    :return: The results dataframe. Contains the following columns:
-
+    :return:
+        The results dataframe. Contains the following columns:
         - **h** (int): Index of the head entity.
         - **t** (int): Index of the tail entity.
         - **n_triangles** (int): Number of compositions for the (h, t) edge.

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -4,13 +4,45 @@
 Utility functions
 """
 
+import warnings
 from collections.abc import Iterable
 from multiprocessing import Pool
 
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
+from pandas.api.types import is_integer_dtype
 from scipy.sparse import coo_array, csc_array, csr_array
+
+
+def check_kg_df_structure(kg_df: pd.DataFrame, h: str, r: str, t: str) -> None:
+    """
+    Utility to perform sanity checks on the structure of the provided DataFrame,
+    to ensure that it encodes a Knowledge Graph in a compatible way.
+
+    :param kg_df:
+        The Knowledge Graph DataFrame.
+    :param h:
+        The name of the column with the IDs of head entities.
+    :param r:
+        The name of the column with the IDs of relation types.
+    :param t:
+        The name of the column with the IDs of tail entities.
+
+    """
+    # check h,r,t columns are present and of an integer type
+    for col_name in [h, r, t]:
+        if col_name in kg_df.columns:
+            if not is_integer_dtype(kg_df[col_name]):
+                raise TypeError(f"Column {col_name} needs to be of an integer dtype")
+        else:
+            raise ValueError(f"DataFrame {kg_df} has no column named {col_name}")
+    # check there are no duplicated (h,r,t) triples
+    if kg_df[[h, r, t]].duplicated().any():
+        warnings.warn(
+            "The Knowledge Graph contains duplicated edges"
+            " -- some functionalities may produce incorrect results"
+        )
 
 
 def node_degrees_and_rels(

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -63,7 +63,7 @@ def composition_count(
         - **n_triangles** (int): Number of compositions for the (h, t) edge.
     """
 
-    n_nodes = max(df[["h", "t"]].max()) + 1
+    n_nodes = df[["h", "t"]].max().max() + 1
     adj = coo_array(
         (np.ones(len(df)), (df.h, df.t)),
         shape=[n_nodes, n_nodes],

--- a/tests/test_edge_topology_toolbox.py
+++ b/tests/test_edge_topology_toolbox.py
@@ -8,14 +8,16 @@ from kg_topology_toolbox import KGTopologyToolbox
 
 df = pd.DataFrame(
     dict(
-        h=[0, 0, 0, 1, 2, 2, 1, 2],
-        t=[1, 1, 2, 2, 0, 0, 1, 2],
-        r=[0, 1, 0, 1, 0, 1, 1, 0],
+        H=[0, 0, 0, 1, 2, 2, 1, 2],
+        T=[1, 1, 2, 2, 0, 0, 1, 2],
+        R=[0, 1, 0, 1, 0, 1, 1, 0],
         n=["a", "b", "c", "d", "e", "f", "g", "h"],
     )
 )
 
-tools = KGTopologyToolbox()
+kgtt = KGTopologyToolbox(
+    kg_df=df, head_column="H", relation_column="R", tail_column="T"
+)
 
 
 @pytest.mark.parametrize("return_metapath_list", [True, False])
@@ -24,7 +26,7 @@ def test_small_graph_metrics(return_metapath_list: bool) -> None:
     # the edge_topology_toolbox
 
     # entity degrees statistics
-    res = tools.edge_degree_cardinality_summary(df)
+    res = kgtt.edge_degree_cardinality_summary()
     assert np.allclose(res["h_unique_rel"], [2, 2, 2, 1, 2, 2, 1, 2])
     assert np.allclose(res["h_degree"], [3, 3, 3, 2, 3, 3, 2, 3])
     assert np.allclose(res["h_degree_same_rel"], [2, 1, 2, 2, 2, 1, 2, 2])
@@ -57,7 +59,7 @@ def test_small_graph_metrics(return_metapath_list: bool) -> None:
     ]
 
     # relation pattern symmetry
-    res = tools.edge_pattern_summary(df, return_metapath_list=return_metapath_list)
+    res = kgtt.edge_pattern_summary(return_metapath_list=return_metapath_list)
     assert np.allclose(
         res["is_loop"], [False, False, False, False, False, False, True, True]
     )

--- a/tests/test_node_topology_toolbox.py
+++ b/tests/test_node_topology_toolbox.py
@@ -8,14 +8,14 @@ from kg_topology_toolbox import KGTopologyToolbox
 
 df = pd.DataFrame(
     dict(
-        h=[0, 0, 0, 1, 2, 2, 2],
-        t=[1, 1, 2, 2, 0, 0, 2],
-        r=[0, 1, 0, 1, 0, 1, 1],
+        H=[0, 0, 0, 1, 2, 2, 2],
+        T=[1, 1, 2, 2, 0, 0, 2],
+        R=[0, 1, 0, 1, 0, 1, 1],
         n=["a", "b", "c", "d", "e", "f", "g"],
     )
 )
 
-tools = KGTopologyToolbox()
+kgtt = KGTopologyToolbox(df, head_column="H", relation_column="R", tail_column="T")
 
 
 @pytest.mark.parametrize("return_relation_list", [True, False])
@@ -24,7 +24,7 @@ def test_small_graph_metrics(return_relation_list: bool) -> None:
     # the node_topology_toolbox
 
     # entity degrees statistics
-    res = tools.node_degree_summary(df, return_relation_list=return_relation_list)
+    res = kgtt.node_degree_summary(return_relation_list=return_relation_list)
     assert np.allclose(res["h_degree"], [3, 1, 3])
     assert np.allclose(res["t_degree"], [2, 2, 3])
     assert np.allclose(res["tot_degree"], [5, 3, 5])

--- a/tests/test_relation_topology_toolbox.py
+++ b/tests/test_relation_topology_toolbox.py
@@ -10,23 +10,23 @@ from kg_topology_toolbox import KGTopologyToolbox
 
 df = pd.DataFrame(
     dict(
-        h=[0, 0, 0, 1, 2, 2, 2, 3, 3, 4],
-        t=[1, 1, 2, 2, 0, 3, 4, 2, 4, 3],
-        r=[0, 1, 0, 1, 0, 1, 1, 0, 0, 1],
+        H=[0, 0, 0, 1, 2, 2, 2, 3, 3, 4],
+        T=[1, 1, 2, 2, 0, 3, 4, 2, 4, 3],
+        R=[0, 1, 0, 1, 0, 1, 1, 0, 0, 1],
         n=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
     )
 )
 
-tools = KGTopologyToolbox()
+kgtt = KGTopologyToolbox(df, head_column="H", relation_column="R", tail_column="T")
 
 
 def test_small_graph_metrics() -> None:
     # Define a small graph on five nodes with all the features tested by
     # the relation_topology_toolbox
 
-    dcs = tools.aggregate_by_relation(tools.edge_degree_cardinality_summary(df))
-    eps = tools.aggregate_by_relation(
-        tools.edge_pattern_summary(df, return_metapath_list=True)
+    dcs = kgtt.aggregate_by_relation(kgtt.edge_degree_cardinality_summary())
+    eps = kgtt.aggregate_by_relation(
+        kgtt.edge_pattern_summary(return_metapath_list=True)
     )
 
     assert np.allclose(dcs["num_triples"], [5, 5])
@@ -73,7 +73,7 @@ def test_small_graph_metrics() -> None:
 
 def test_jaccard_similarity() -> None:
     # jaccard_similarity_relation_sets
-    res = tools.jaccard_similarity_relation_sets(df)
+    res = kgtt.jaccard_similarity_relation_sets()
     assert np.allclose(res["jaccard_head_head"], [2 / 5])
     assert np.allclose(res["jaccard_tail_tail"], [3 / 5])
     assert np.allclose(res["jaccard_head_tail"], [2 / 5])
@@ -86,5 +86,5 @@ def test_jaccard_similarity() -> None:
 )
 def test_ingram_affinity(min_max_norm: bool, expected: List[float]) -> None:
     # relational_affinity_ingram
-    res = tools.relational_affinity_ingram(df, min_max_norm)
+    res = kgtt.relational_affinity_ingram(min_max_norm)
     assert np.allclose(res["edge_weight"], expected)

--- a/tests/test_relation_topology_toolbox.py
+++ b/tests/test_relation_topology_toolbox.py
@@ -24,10 +24,8 @@ def test_small_graph_metrics() -> None:
     # Define a small graph on five nodes with all the features tested by
     # the relation_topology_toolbox
 
-    dcs = kgtt.aggregate_by_relation(kgtt.edge_degree_cardinality_summary())
-    eps = kgtt.aggregate_by_relation(
-        kgtt.edge_pattern_summary(return_metapath_list=True)
-    )
+    dcs = kgtt.edge_degree_cardinality_summary(aggregate_by_r=True)
+    eps = kgtt.edge_pattern_summary(return_metapath_list=True, aggregate_by_r=True)
 
     assert np.allclose(dcs["num_triples"], [5, 5])
     assert np.allclose(dcs["frac_triples"], [0.5, 0.5])


### PR DESCRIPTION
Class refactoring for KGTopologyToolbox. Main changes:

* Add a constructor: the edge dataframe is now passed when instantiating the class (instead of when calling the single methods), and initial checks on the data (presence of h,r,t columns of int type, check for duplicated edges) are performed at that stage.
* Improve modularity: instead of just having three big "summary" methods, which can take long to run, add also the possibility for the user to compute single statistics (wasn't able to do this for the `edge_pattern_summary` method, as the different statistics there share a lot of intermediate steps to be computed, and the separation is not so clear without duplicating work - ideas welcome).
* Move `aggregate_by_relation` to utilities (can be called on any df that is indexed over the single edges), and add the possibility to aggregate the output as an option to the edge-level summary methods.
* Cache outputs that are reused across different methods.