### PR TITLE
Relation filtering for edge methods + sparse metapath counting

### DIFF
--- a/docs/source/notebooks/ogb_biokg_demo.ipynb
+++ b/docs/source/notebooks/ogb_biokg_demo.ipynb
@@ -22,9 +22,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found existing installation: kg-topology-toolbox 0.1.0\n",
-      "Uninstalling kg-topology-toolbox-0.1.0:\n",
-      "  Successfully uninstalled kg-topology-toolbox-0.1.0\n"
+      "Found existing installation: kg-topology-toolbox 1.0.0\n",
+      "Uninstalling kg-topology-toolbox-1.0.0:\n",
+      "  Successfully uninstalled kg-topology-toolbox-1.0.0\n"
      ]
     }
    ],
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +181,7 @@
        "[5088434 rows x 3 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -209,14 +209,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/nethome/albertoc/research/knowledge_graphs/kg-topology-toolbox/.venv/lib/python3.10/site-packages/kg_topology_toolbox/topology_toolbox.py:64: UserWarning: The Knowledge Graph contains duplicated edges -- some functionalities may produce incorrect results\n",
+      "/nethome/albertoc/research/knowledge_graphs/kg-topology-toolbox/.venv/lib/python3.10/site-packages/kg_topology_toolbox/utils.py:42: UserWarning: The Knowledge Graph contains duplicated edges -- some functionalities may produce incorrect results\n",
       "  warnings.warn(\n"
      ]
     }
@@ -233,12 +233,76 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>h</th>\n",
+       "      <th>r</th>\n",
+       "      <th>t</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3854407</th>\n",
+       "      <td>1972</td>\n",
+       "      <td>45</td>\n",
+       "      <td>1972</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4000534</th>\n",
+       "      <td>1972</td>\n",
+       "      <td>45</td>\n",
+       "      <td>1972</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            h   r     t\n",
+       "3854407  1972  45  1972\n",
+       "4000534  1972  45  1972"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# find duplicated edges\n",
+    "biokg_df.loc[biokg_df.duplicated(keep=False)]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Node-level analysis\n",
     "\n",
-    "The method `node_degree_summary` provides a summary of the degrees of each individual node in the knowledge graph. The returned dataframe is indexed on the node ID.\n",
+    "The method `node_degree_summary` provides a summary of the degrees of each individual node in the knowledge graph. The returned DataFrame is indexed on the node ID.\n",
     "\n",
     "- `h_degree` is the number of edges coming out from the node;\n",
     "- `t_degree` is the number of edges going into the node;\n",
@@ -894,7 +958,7 @@
     "\n",
     "![image info](../images/edge_patterns.png)\n",
     "\n",
-    "For inverse/inference, the method also provides the number and types of unique relations `r'` realizing the counterpart edges; for composition, the number of triangles supported by the edge is provided (the unique metapaths `[r_1, r_2]` can also be listed by setting `return_metapath_list=True` when calling the method)."
+    "For inverse/inference, the method also provides the number and types of unique relations `r'` realizing the counterpart edges; for composition, the number of triangles supported by the edge is provided."
    ]
   },
   {
@@ -1211,6 +1275,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we need to identify the different metapaths `[r_1, r_2]` that give triangles `(h,r1,x) - (x,r2,t)` over an edge `(h,r,t)`, we can do so by setting `return_metapath_list=True` in the call of `edge_pattern_summary`. In order to disaggregate the total number of triangles over an edge into separate counts for each existing metapath, the `edge_metapath_count` method should be used instead. \n",
+    "\n",
+    "We can now easily produce a global view of the distribution of topological properties."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
@@ -1275,6 +1348,225 @@
     "    sns.histplot(x=x, stat=\"probability\", binwidth=1, binrange=[0, x.max() + 1], ax=axn)\n",
     "    axn.set_xlabel(f\"sqrt({metric})\")\n",
     "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering relation types\n",
+    "\n",
+    "The edge-level methods presented in the previous section simultaneously compute statistics for all edges in the KG, and this can be expensive on larger graphs. Moreover, in many practical cases the user might be interested in looking only at the properties of edges of one or few specific relation types.\n",
+    "\n",
+    "The methods `edge_degree_cardinality_summary`, `edge_pattern_summary` and `edge_metapath_count` can be passed a list of relation type IDs to restrict computations of their outputs to edges of those specific relation types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>h</th>\n",
+       "      <th>r</th>\n",
+       "      <th>t</th>\n",
+       "      <th>r1</th>\n",
+       "      <th>r2</th>\n",
+       "      <th>n_triangles</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>334382</td>\n",
+       "      <td>732</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1225</td>\n",
+       "      <td>41</td>\n",
+       "      <td>2</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>334382</td>\n",
+       "      <td>732</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1225</td>\n",
+       "      <td>39</td>\n",
+       "      <td>2</td>\n",
+       "      <td>123</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>334382</td>\n",
+       "      <td>732</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1225</td>\n",
+       "      <td>38</td>\n",
+       "      <td>2</td>\n",
+       "      <td>200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>334382</td>\n",
+       "      <td>732</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1225</td>\n",
+       "      <td>37</td>\n",
+       "      <td>2</td>\n",
+       "      <td>27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>334382</td>\n",
+       "      <td>732</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1225</td>\n",
+       "      <td>36</td>\n",
+       "      <td>2</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>732149</th>\n",
+       "      <td>4953327</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2492</td>\n",
+       "      <td>13</td>\n",
+       "      <td>41</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>732150</th>\n",
+       "      <td>4953327</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2492</td>\n",
+       "      <td>11</td>\n",
+       "      <td>41</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>732151</th>\n",
+       "      <td>4953327</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2492</td>\n",
+       "      <td>6</td>\n",
+       "      <td>41</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>732152</th>\n",
+       "      <td>4953327</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2492</td>\n",
+       "      <td>4</td>\n",
+       "      <td>41</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>732153</th>\n",
+       "      <td>4953327</td>\n",
+       "      <td>1529</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2492</td>\n",
+       "      <td>2</td>\n",
+       "      <td>41</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>732154 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          index     h   r     t  r1  r2  n_triangles\n",
+       "0        334382   732   7  1225  41   2           10\n",
+       "1        334382   732   7  1225  39   2          123\n",
+       "2        334382   732   7  1225  38   2          200\n",
+       "3        334382   732   7  1225  37   2           27\n",
+       "4        334382   732   7  1225  36   2            6\n",
+       "...         ...   ...  ..   ...  ..  ..          ...\n",
+       "732149  4953327  1529  24  2492  13  41            2\n",
+       "732150  4953327  1529  24  2492  11  41            2\n",
+       "732151  4953327  1529  24  2492   6  41            2\n",
+       "732152  4953327  1529  24  2492   4  41            1\n",
+       "732153  4953327  1529  24  2492   2  41            2\n",
+       "\n",
+       "[732154 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filtered_metapath_counts = kgtt.edge_metapath_count(filter_relations=[7, 24])\n",
+    "filtered_metapath_counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The previous cell computes the number of triangles of each existing `(r1, r2)` metapath, but only over `(h,r,t)` edges of the two relation types with ID 7 and 24 (the column `index` gives the index of the edge in the `biokkg_df` DataFrame). This is the same as calling `kgtt.edge_metapath_count().query('r==7 or r==24')`, but the computation is much cheaper and faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "r\n",
+       "24    413366\n",
+       "7     318788\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filtered_metapath_counts.r.value_counts()"
    ]
   },
   {
@@ -2267,7 +2559,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv38",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -2281,7 +2573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -547,10 +547,12 @@ class KGTopologyToolbox:
 
         # composition & metapaths
         if return_metapath_list:
-            counts = self.edge_metapath_count(
-                filter_relations,
-                composition_chunk_size,
-                composition_workers,
+            counts = composition_count(
+                df_triangles,
+                chunk_size=composition_chunk_size,
+                workers=composition_workers,
+                metapaths=True,
+                directed=True,
             )
             counts["metapath"] = (
                 counts["r1"].astype(str) + "-" + counts["r2"].astype(str)

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -5,8 +5,9 @@
 Topology toolbox main functionalities
 """
 
-from functools import cache
 import multiprocessing as mp
+from functools import cache
+
 import numpy as np
 import pandas as pd
 from scipy.sparse import coo_array
@@ -271,7 +272,7 @@ class KGTopologyToolbox:
         return df_res
 
     def edge_degree_cardinality_summary(
-        self, filter_relations: list = [], aggregate_by_r: bool = False
+        self, filter_relations: list[int] = [], aggregate_by_r: bool = False
     ) -> pd.DataFrame:
         """
         For each edge in the KG, compute the number of edges with the same head
@@ -286,8 +287,8 @@ class KGTopologyToolbox:
         as the original Knowledge Graph dataframe.
 
         :param filter_relations:
-            Compute the output only for the edges with relation in this list
-            of relation IDs.
+            If not empty, compute the output only for the edges with relation
+            in this list of relation IDs.
         :param aggregate_by_r:
             If True, return metrics aggregated by relation type
             (the output DataFrame will be indexed over relation IDs).
@@ -331,9 +332,7 @@ class KGTopologyToolbox:
             how="left",
         )
         df_res["tot_degree"] = (
-            df_res.h_degree.values
-            + df_res.t_degree.values
-            - num_parallel.n_parallel.values
+            df_res.h_degree + df_res.t_degree - num_parallel.n_parallel.values
         )
         # when restricting to the relation type, there is only one edge
         # (the edge itself) that is double-counted
@@ -351,7 +350,7 @@ class KGTopologyToolbox:
     def edge_pattern_summary(
         self,
         return_metapath_list: bool = False,
-        filter_relations: list = [],
+        filter_relations: list[int] = [],
         aggregate_by_r: bool = False,
         composition_chunk_size: int = 2**8,
         composition_workers: int = min(32, mp.cpu_count() - 1 or 1),
@@ -366,10 +365,10 @@ class KGTopologyToolbox:
 
         :param return_metapath_list:
             If True, return the list of unique metapaths for all
-            triangles supported over one edge. WARNING: very expensive for large graphs.
+            triangles supported over each edge. WARNING: very expensive for large graphs.
         :param filter_relations:
-            Compute the output only for the edges with relation in this list
-            of relation IDs.
+            If not empty, compute the output only for the edges with relation
+            in this list of relation IDs.
         :param aggregate_by_r:
             If True, return metrics aggregated by relation type
             (the output DataFrame will be indexed over relation IDs).

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -557,14 +557,14 @@ class KGTopologyToolbox:
         df_res["has_inference"] = df_res["n_inference_relations"] > 0
 
         # composition & metapaths
+        counts = composition_count(
+            df_triangles,
+            chunk_size=composition_chunk_size,
+            workers=composition_workers,
+            metapaths=return_metapath_list,
+            directed=True,
+        )
         if return_metapath_list:
-            counts = composition_count(
-                df_triangles,
-                chunk_size=composition_chunk_size,
-                workers=composition_workers,
-                metapaths=True,
-                directed=True,
-            )
             # turn (r1, r2) into "r1-r2" string for metapaths
             counts["metapath"] = (
                 counts["r1"].astype(str) + "-" + counts["r2"].astype(str)
@@ -583,21 +583,13 @@ class KGTopologyToolbox:
             df_res["metapath_list"] = df_res["metapath_list"].apply(
                 lambda agg: agg if isinstance(agg, list) else []
             )
-            df_res["n_triangles"] = df_res["n_triangles"].fillna(0).astype(int)
         else:
-            counts = composition_count(
-                df_triangles,
-                chunk_size=composition_chunk_size,
-                workers=composition_workers,
-                directed=True,
-            )
             df_res = df_res.merge(
                 counts,
                 on=["h", "t"],
                 how="left",
             )
-            df_res["n_triangles"] = df_res["n_triangles"].fillna(0).astype(int)
-
+        df_res["n_triangles"] = df_res["n_triangles"].fillna(0).astype(int)
         df_res["has_composition"] = df_res["n_triangles"] > 0
 
         # undirected composition

--- a/src/kg_topology_toolbox/topology_toolbox.py
+++ b/src/kg_topology_toolbox/topology_toolbox.py
@@ -500,7 +500,7 @@ class KGTopologyToolbox:
         else:
             rel_df = inference_df = inverse_df = self.df
             df_triangles = df_triangles_und = df_wo_loops
-        df_res = df_res = pd.DataFrame(
+        df_res = pd.DataFrame(
             {"h": rel_df.h, "r": rel_df.r, "t": rel_df.t, "is_symmetric": False}
         )
         # symmetry-asymmetry

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -194,14 +194,15 @@ def _composition_count_worker(
     n_rels = adj_csr.shape[0] // n_nodes
     adj_2hop = adj_csr @ adj_csc
     adj_composition = (adj_2hop.tocsc() * (adj_mask > 0)).tocoo()
-    col_shift = adj_composition.col + tail_shift
     if n_rels > 1:
+        h, r1 = np.divmod(adj_composition.row, n_rels)
+        r2, t = np.divmod(adj_composition.col + tail_shift, n_nodes)
         df_composition = pd.DataFrame(
             dict(
-                h=adj_composition.row // n_rels,
-                t=col_shift % n_nodes,
-                r1=adj_composition.row % n_rels,
-                r2=col_shift // n_nodes,
+                h=h,
+                t=t,
+                r1=r1,
+                r2=r2,
                 n_triangles=adj_composition.data,
             )
         )
@@ -209,7 +210,7 @@ def _composition_count_worker(
         df_composition = pd.DataFrame(
             dict(
                 h=adj_composition.row,
-                t=col_shift,
+                t=adj_composition.col + tail_shift,
                 n_triangles=adj_composition.data,
             )
         )

--- a/src/kg_topology_toolbox/utils.py
+++ b/src/kg_topology_toolbox/utils.py
@@ -233,8 +233,11 @@ def composition_count(
         processed together.
     :param workers:
         Number of workers processing chunks concurrently
+    :param metapaths:
+        If True, the number of composition is computed separately for each
+        unique metapath.
     :param directed:
-        Boolean flag. If false, bidirectional edges are considered for
+        If False, bidirectional edges are considered for
         triangles by adding the adjacency matrix and its transposed. Default: True.
 
     :return:

--- a/tests/test_edge_topology_toolbox.py
+++ b/tests/test_edge_topology_toolbox.py
@@ -23,13 +23,14 @@ kgtt = KGTopologyToolbox(
 
 
 def test_edge_metapath_count() -> None:
-    res = kgtt.edge_metapath_count()
+    res = kgtt.edge_metapath_count(composition_chunk_size=3)
     assert np.allclose(res["index"], [2, 2])
     assert np.allclose(res["h"], [0, 0])
     assert np.allclose(res["r"], [0, 0])
     assert np.allclose(res["t"], [2, 2])
-    assert np.allclose(res["r1"], [0, 1])
-    assert np.allclose(res["r2"], [1, 1])
+    assert set(zip(res["r1"].values.tolist(), res["r2"].values.tolist())) == set(
+        [(0, 1), (1, 1)]
+    )
     assert np.allclose(res["n_triangles"], [1, 1])
 
 
@@ -71,7 +72,9 @@ def test_edge_degree_cardinality_summary() -> None:
 @pytest.mark.parametrize("return_metapath_list", [True, False])
 def test_edge_pattern_summary(return_metapath_list: bool) -> None:
     # relation pattern symmetry
-    res = kgtt.edge_pattern_summary(return_metapath_list=return_metapath_list)
+    res = kgtt.edge_pattern_summary(
+        return_metapath_list=return_metapath_list, composition_chunk_size=3
+    )
     assert np.allclose(
         res["is_loop"], [False, False, False, False, False, False, True, True]
     )
@@ -96,7 +99,7 @@ def test_edge_pattern_summary(return_metapath_list: bool) -> None:
     assert np.allclose(res["n_triangles"], [0, 0, 2, 0, 0, 0, 0, 0])
     assert np.allclose(res["n_undirected_triangles"], [3, 3, 2, 6, 2, 2, 0, 0])
     if return_metapath_list:
-        assert res["metapath_list"][2] == ["0-1", "1-1"]
+        assert set(res["metapath_list"][2]) == set(["0-1", "1-1"])
 
 
 def test_filter_relations() -> None:

--- a/tests/test_edge_topology_toolbox.py
+++ b/tests/test_edge_topology_toolbox.py
@@ -22,12 +22,19 @@ kgtt = KGTopologyToolbox(
 )
 
 
-@pytest.mark.parametrize("return_metapath_list", [True, False])
-def test_small_graph_metrics(return_metapath_list: bool) -> None:
-    # Define a small graph with all the features tested by
-    # the edge_topology_toolbox
+def test_edge_metapath_count() -> None:
+    res = kgtt.edge_metapath_count()
+    assert np.allclose(res["index"], [2, 2])
+    assert np.allclose(res["h"], [0, 0])
+    assert np.allclose(res["r"], [0, 0])
+    assert np.allclose(res["t"], [2, 2])
+    assert np.allclose(res["r1"], [0, 1])
+    assert np.allclose(res["r2"], [1, 1])
+    assert np.allclose(res["n_triangles"], [1, 1])
 
-    # entity degrees statistics
+
+def test_edge_degree_cardinality_summary() -> None:
+    # edge degrees statistics
     res = kgtt.edge_degree_cardinality_summary()
     assert np.allclose(res["h_unique_rel"], [2, 2, 2, 1, 2, 2, 1, 2])
     assert np.allclose(res["h_degree"], [3, 3, 3, 2, 3, 3, 2, 3])
@@ -60,6 +67,9 @@ def test_small_graph_metrics(return_metapath_list: bool) -> None:
         "M:M",
     ]
 
+
+@pytest.mark.parametrize("return_metapath_list", [True, False])
+def test_edge_pattern_summary(return_metapath_list: bool) -> None:
     # relation pattern symmetry
     res = kgtt.edge_pattern_summary(return_metapath_list=return_metapath_list)
     assert np.allclose(
@@ -92,6 +102,7 @@ def test_small_graph_metrics(return_metapath_list: bool) -> None:
 def test_filter_relations() -> None:
     for rels in [[0], [1], [0, 1]]:
         for method in [
+            kgtt.edge_metapath_count,
             kgtt.edge_degree_cardinality_summary,
             partial(kgtt.edge_pattern_summary, return_metapath_list=True),
         ]:

--- a/tests/test_edge_topology_toolbox.py
+++ b/tests/test_edge_topology_toolbox.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 from functools import partial
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -95,9 +96,9 @@ def test_filter_relations() -> None:
             partial(kgtt.edge_pattern_summary, return_metapath_list=True),
         ]:
             # compare outputs of standard method call and filtered call
-            res_all = method()
+            res_all = method()  # type: ignore
             res_all = res_all[res_all.r.isin(rels)]
-            res_filtered = method(filter_relations=rels)
+            res_filtered = method(filter_relations=rels)  # type: ignore
             assert np.all(res_all.index.values == res_filtered.index.values)
             for c in res_all.columns:
                 if c == "metapath_list":

--- a/tests/test_node_topology_toolbox.py
+++ b/tests/test_node_topology_toolbox.py
@@ -19,10 +19,7 @@ kgtt = KGTopologyToolbox(df, head_column="H", relation_column="R", tail_column="
 
 
 @pytest.mark.parametrize("return_relation_list", [True, False])
-def test_small_graph_metrics(return_relation_list: bool) -> None:
-    # Define a small graph with all the features tested by
-    # the node_topology_toolbox
-
+def test_node_degree_summary(return_relation_list: bool) -> None:
     # entity degrees statistics
     res = kgtt.node_degree_summary(return_relation_list=return_relation_list)
     assert np.allclose(res["h_degree"], [3, 1, 3])

--- a/tests/test_relation_topology_toolbox.py
+++ b/tests/test_relation_topology_toolbox.py
@@ -20,10 +20,7 @@ df = pd.DataFrame(
 kgtt = KGTopologyToolbox(df, head_column="H", relation_column="R", tail_column="T")
 
 
-def test_small_graph_metrics() -> None:
-    # Define a small graph on five nodes with all the features tested by
-    # the relation_topology_toolbox
-
+def test_aggregate_by_r() -> None:
     dcs = kgtt.edge_degree_cardinality_summary(aggregate_by_r=True)
     eps = kgtt.edge_pattern_summary(return_metapath_list=True, aggregate_by_r=True)
 


### PR DESCRIPTION
Added the possibility to select the relation types you are interested in for the edge methods `edge_degree_cardinality_summary`, `edge_pattern_summary`. This allows in principle to reduce a bit the computational requirements (in particular, when computing triangles and metapaths) compared to working on the full dataframe.

I was also thinking that, in principle, it should be possible to compute also metapaths using sparse matmuls. The number of triangles is computed with (A@A) * (A > 0), with A the adjacency matrix with A[h,t] = #edges between h,t. If we take instead the 3D adjacency matrix B, with B[h,r,t] = 1 if there is an edge of type r between h and t, then the number of triangles of a given metapath can be computed with  `np.einsum("ijk,kxy->ijxy", B, B) * (A[:, None, None, :] > 0)`, which is a 4D matrix C with C[h, r1, r2, t] = #triangles of metapath r1-r2 between h and t... however, I don't think that scipy.sparse supports sparse 3D matrices and tensor contractions like this.

Fixed also the default value of `composition_workers`, which takes now into consideration the number of cores available (capped at 32, as that seems to be the optimal ballpark on larger nodes).